### PR TITLE
Use bcrypt==3.0.2 to fix yarn fails on Linux x64 #217

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.151.0",
-    "bcrypt": "^3.0.0",
+    "bcrypt": "^3.0.2",
     "body-parser": "^1.17.1",
     "cors": "^2.8.1",
     "dotenv": "^4.0.0",


### PR DESCRIPTION
Upgrading into 3.0.2 solves yarn install failure.