### PR TITLE
Fix build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "node dist",
     "dev": "NODE_ENV=development node_modules/.bin/ts-node-dev --respawn src",
-    "build": "tsc -p tsconfig.prod.json && cp -rf src/private dist/private",
+    "build": "tsc -p tsconfig.prod.json && cp -rf src/private dist/",
     "lint": "tslint 'src/**/*.ts'",
     "format": "prettier --write 'src/**/*.ts'",
     "precommit": "lint-staged",


### PR DESCRIPTION
Build command was copying files to the wrong folder (`dist/private/private/`):

```
cp -rf -vvv src/private dist/private 
'src/private/emailTemplates/base.html' -> 'dist/private/private/emailTemplates/base.html'
'src/private/emailTemplates/conversationCron.html' -> 'dist/private/private/emailTemplates/conversationCron.html'
'src/private/emailTemplates/conversationDetail.html' -> 'dist/private/private/emailTemplates/conversationDetail.html'
'src/private/emailTemplates/notification.html' -> 'dist/private/private/emailTemplates/notification.html'
'src/private/emailTemplates/unsubscribe.html' -> 'dist/private/private/emailTemplates/unsubscribe.html'
'src/private/emailTemplates/resetPassword.html' -> 'dist/private/private/emailTemplates/resetPassword.html'
'src/private/emailTemplates/userInvitation.html' -> 'dist/private/private/emailTemplates/userInvitation.html'
```

New command:

```
cp -rf -vvv src/private dist/
'src/private/emailTemplates/base.html' -> 'dist/private/emailTemplates/base.html'
'src/private/emailTemplates/conversationCron.html' -> 'dist/private/emailTemplates/conversationCron.html'
'src/private/emailTemplates/conversationDetail.html' -> 'dist/private/emailTemplates/conversationDetail.html'
'src/private/emailTemplates/notification.html' -> 'dist/private/emailTemplates/notification.html'
'src/private/emailTemplates/unsubscribe.html' -> 'dist/private/emailTemplates/unsubscribe.html'
'src/private/emailTemplates/resetPassword.html' -> 'dist/private/emailTemplates/resetPassword.html'
'src/private/emailTemplates/userInvitation.html' -> 'dist/private/emailTemplates/userInvitation.html'
```