### PR TITLE
fix channel notification link format

### DIFF
--- a/src/__tests__/notificationTools.test.ts
+++ b/src/__tests__/notificationTools.test.ts
@@ -97,7 +97,7 @@ describe('testings helper methods', () => {
       notifType: NOTIFICATION_TYPES.CHANNEL_MEMBERS_CHANGE,
       title: content,
       content,
-      link: `/inbox/${channel._id}`,
+      link: `/inbox?channelId=${channel._id}`,
       receivers: channel && channel.memberIds ? channel.memberIds.filter(id => id !== channel.userId) : null,
     });
 

--- a/src/data/resolvers/mutations/channels.ts
+++ b/src/data/resolvers/mutations/channels.ts
@@ -20,7 +20,7 @@ export const sendChannelNotifications = async (channel: IChannelDocument) => {
     notifType: NOTIFICATION_TYPES.CHANNEL_MEMBERS_CHANGE,
     title: content,
     content,
-    link: `/inbox/${channel._id}`,
+    link: `/inbox?channelId=${channel._id}`,
 
     // exclude current user
     receivers: (channel.memberIds || []).filter(id => id !== channel.userId),


### PR DESCRIPTION
`/inbox/{channelId}` is not a valid route in the inbox UI module so clicking a notification created with this format breaks the inbox for the user. This modifies the link format to open the inbox with a filter on the specific channel the notified user was just added to.