### PR TITLE
Prevent possible OOM due to excessive JSON parsing of large stringified arrays.

### DIFF
--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -5,7 +5,7 @@ import resolvers from './data/resolvers';
 import typeDefs from './data/schema';
 import { Conversations, Customers } from './db/models';
 import { graphqlPubsub } from './pubsub';
-import { get, getArray, set, setArray } from './redisClient';
+import { addToArray, get, inArray, removeFromArray, set } from './redisClient';
 
 // load environment variables
 dotenv.config();
@@ -105,25 +105,23 @@ const apolloServer = new ApolloServer({
         const parsedMessage = JSON.parse(message.toString()).id || {};
 
         if (parsedMessage.type === 'messengerConnected') {
-          // get status from redis
-          const connectedClients = await getArray('connectedClients');
-          const clients = await getArray('clients');
-
           webSocket.messengerData = parsedMessage.value;
 
           const customerId = webSocket.messengerData.customerId;
 
-          if (!connectedClients.includes(customerId)) {
-            connectedClients.push(customerId);
-            await setArray('connectedClients', connectedClients);
+          // get status from redis
+          const inConnectedClients = await inArray('connectedClients', customerId);
+          const inClients = await inArray('clients', customerId);
+
+          if (!inConnectedClients) {
+            await addToArray('connectedClients', customerId);
           }
 
           // Waited for 1 minute to reconnect in disconnect hook and disconnect hook
           // removed this customer from connected clients list. So it means this customer
           // is back online
-          if (!clients.includes(customerId)) {
-            clients.push(customerId);
-            await setArray('clients', clients);
+          if (!inClients) {
+            await addToArray('clients', customerId);
 
             // mark as online
             await Customers.markCustomerAsActive(customerId);
@@ -144,9 +142,6 @@ const apolloServer = new ApolloServer({
       const messengerData = webSocket.messengerData;
 
       if (messengerData) {
-        // get status from redis
-        let connectedClients = await getArray('connectedClients');
-
         const customerId = messengerData.customerId;
         const integrationId = messengerData.integrationId;
 
@@ -154,21 +149,18 @@ const apolloServer = new ApolloServer({
         // If client refreshes his browser, It will trigger disconnect, connect hooks.
         // So to determine this issue. We are marking as disconnected here and waiting
         // for 1 minute to reconnect.
-        connectedClients.splice(connectedClients.indexOf(customerId), 1);
-        await setArray('connectedClients', connectedClients);
+        await removeFromArray('connectedClients', customerId);
 
         setTimeout(async () => {
           // get status from redis
-          connectedClients = await getArray('connectedClients');
-          const clients = await getArray('clients');
+          const inNewConnectedClients = await inArray('connectedClients', customerId);
           const customerLastStatus = await get(`customer_last_status_${customerId}`);
 
-          if (connectedClients.includes(customerId)) {
+          if (inNewConnectedClients) {
             return;
           }
 
-          clients.splice(clients.indexOf(customerId), 1);
-          await setArray('clients', clients);
+          await removeFromArray('clients', customerId);
 
           // mark as offline
           await Customers.markCustomerAsNotActive(customerId);

--- a/src/redisClient.ts
+++ b/src/redisClient.ts
@@ -74,17 +74,46 @@ export const set = (key: string, value: any) => {
 };
 
 /*
- * Get array
+ * Check if value exists in set
  */
-export const getArray = async (key: string): Promise<any> => {
-  const value = await get(key, '[]');
+export const inArray = async (setKey: string, setMember: string): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    client.sismember(setKey, setMember, (error, reply) => {
+      if (error) {
+        return reject(error);
+      }
 
-  return JSON.parse(value);
+      return resolve(reply);
+    });
+  });
 };
 
 /*
- * Set array
+ * Add a value to a set or do nothing if it already exists
  */
-export const setArray = (key: string, value: any[]) => {
-  client.set(key, JSON.stringify(value));
+export const addToArray = (setKey: string, setMember: string) => {
+  return new Promise((resolve, reject) => {
+    client.sadd(setKey, setMember, (error, reply) => {
+      if (error) {
+        return reject(error);
+      }
+
+      return resolve(reply);
+    });
+  });
+};
+
+/*
+ * Remove a value from a set or do nothing if it is not present
+ */
+export const removeFromArray = (setKey: string, setMember: string) => {
+  return new Promise((resolve, reject) => {
+    client.srem(setKey, setMember, (error, reply) => {
+      if (error) {
+        return reject(error);
+      }
+
+      return resolve(reply);
+    });
+  });
 };


### PR DESCRIPTION
If many clients are connected to a single instance the string value can get quite large. With default node settings (512mb heap space) parsing the string into an array can cause OOM with just a few thousand connections.

This replaces the string value with a redis `Set` so the DB can handle the functionality used to implement the online state.

Online status logic stays the same (users are marked offline after 1 full minute from their last disconnect). The memory footprint of the instance is reduced so the `--max-old-space-size` flag may not be necessary in the `start` script anymore.

If the Redis instance is restarted at the same time a migration should not be necessary, but if Redis still has a `String` value in those keys, then it will issue a warning instead of creating a new `Set`.