### PR TITLE
Change dockerfile to make full build inside container [WIP]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,9 @@
 .env*
 .git*
 .prettierrc
-.snyk
+# .snyk
+.yarn
+.pnp.js
 Dockerfile*
 google_cred.json.sample
 scripts

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dump.rdb
 *.swp
 *.swo
 .migrate
+.yarn
 
 # Google config file
 google_cred.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 FROM erxes/runner:latest
 WORKDIR /erxes-api/
 RUN chown -R node:node /erxes-api
+COPY --chown=node:node package.json /erxes-api/package.json
+COPY --chown=node:node .* /erxes-api/
+RUN yarn install
 COPY --chown=node:node . /erxes-api
+RUN yarn build
 USER node
 EXPOSE 3300
 ENTRYPOINT [ "node", "--max_old_space_size=8192", "dist" ]


### PR DESCRIPTION
Currently image is built in CI-pipeline so that first steps are made outside dockerfile and only the built distribution is moved in.

That causes however problems if somebody would like to build the image without the full CI-pipeline.

This is WIP, it works already but it produces very large images.