### PR TITLE
Implemented user assigned isolation

### DIFF
--- a/src/apolloClient.ts
+++ b/src/apolloClient.ts
@@ -80,7 +80,11 @@ const apolloServer = new ApolloServer({
         scopeBrandIds = brandIds;
       }
 
-      if (!user.isOwner) {
+      if (!user.isOwner && scopeBrandIds.length) {
+        // Select non-existent or empty arrays too
+        scopeBrandIds.push(null);
+        scopeBrandIds.push([]);
+
         brandIdSelector = { _id: { $in: scopeBrandIds } };
         commonQuerySelector = { scopeBrandIds: { $in: scopeBrandIds } };
         commonQuerySelectorElk = { terms: { scopeBrandIds } };

--- a/src/data/resolvers/queries/conversations.ts
+++ b/src/data/resolvers/queries/conversations.ts
@@ -93,6 +93,7 @@ const conversationQueries = {
     // initiate query builder
     const qb = new QueryBuilder(params, {
       _id: user._id,
+      isOwner: user.isOwner,
       starredConversationIds: user.starredConversationIds,
     });
 


### PR DESCRIPTION
We have implemented an user assigned chat isolation option to follow this behavior:

1 - New chat appears for every one in the channel(no assigned user)
2 - An user assumes the chat, meaning he is assigned to that chat
3 - Chat with the new designated user "disappears" from other users
4 - If need, the user previous assigned or the admin, can assign other user to continue the chat(like a transfer)

We also made a change _(in the option "USE_BRAND_RESTRICTIONS")_ on user selection by brand because the behavior wasn't loading the users correctly in this situations:

- Current logged user profile has an empty array on "brandIds" property 
- User hasn't the "brandIds" property or has an empty array

Expected behavior: If user has no brand, it should load all brands

To use this behavior, you should set the ENV property "USE_CHAT_RESTRICTIONS" to "true"

.env file:
`USE_CHAT_RESTRICTIONS=true`
