### PR TITLE
prevent leaking private data from configs to all users

### DIFF
--- a/src/data/resolvers/queries/configs.ts
+++ b/src/data/resolvers/queries/configs.ts
@@ -1,5 +1,5 @@
 import { Configs } from '../../../db/models';
-import { moduleRequireLogin } from '../../permissions/wrappers';
+import { moduleCheckPermission, moduleRequireLogin } from '../../permissions/wrappers';
 import { IContext } from '../../types';
 import { frontendEnv, getEnv, sendRequest } from '../../utils';
 
@@ -53,5 +53,7 @@ const configQueries = {
 };
 
 moduleRequireLogin(configQueries);
+
+moduleCheckPermission(configQueries, 'generalSettings', 'showGeneralSettings');
 
 export default configQueries;


### PR DESCRIPTION
The general settings configs now contain fields that should not be exposed to all users in the system such as cloud credentials and mail server logins.

This uses the now-unused `showGeneralSettings` permissions to match the `manageGeneralSettings` permission set on config mutations so that data for users without the appropriate level isn't returned.