### PR TITLE
fix issue when no file type is specified

### DIFF
--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -40,21 +40,11 @@ export const checkFile = async (file, source?: string) => {
     return 'Invalid file type';
   }
 
-  const defaultMimeTypes = [
-    'image/png',
-    'image/jpeg',
-    'image/jpg',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'application/pdf',
-    'image/gif',
-  ];
-
   const UPLOAD_FILE_TYPES = await getConfig(source === 'widgets' ? 'WIDGETS_UPLOAD_FILE_TYPES' : 'UPLOAD_FILE_TYPES');
 
   const { mime } = ft;
 
-  if (!((UPLOAD_FILE_TYPES && UPLOAD_FILE_TYPES.split(',')) || defaultMimeTypes).includes(mime)) {
+  if (UPLOAD_FILE_TYPES && !UPLOAD_FILE_TYPES.split(',').includes(mime)) {
     return 'Invalid configured file type';
   }
 


### PR DESCRIPTION
This change fix the issue where if no file type is specified, the system uses a "default" file type const, but it should allow all media types

This change follows the instruction defined here:
![image](https://user-images.githubusercontent.com/19454127/78460315-2bc93500-7696-11ea-8bdb-45231d346c40.png)

