### PR TITLE
Widget: Conversation detail bug 

### DIFF
--- a/src/data/resolvers/mutations/engageUtils.ts
+++ b/src/data/resolvers/mutations/engageUtils.ts
@@ -305,6 +305,7 @@ const sendViaMessenger = async ({ engageMessage, customersSelector, user }: IEng
         fromUserId,
         ...(messenger ? messenger.toJSON() : {}),
       },
+      internal: false,
       conversationId,
       userId: fromUserId,
       customerId: customer._id,


### PR DESCRIPTION
[ISSUE 1161](https://github.com/erxes/erxes/issues/2390)

In-app Messenger conversation details do not show up when sent from Engage
